### PR TITLE
Require explicit JWT secret configuration

### DIFF
--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -1,14 +1,12 @@
 import { Pool } from 'pg';
-import dotenv from 'dotenv';
-
-dotenv.config();
+import { env } from './env';
 
 const pool = new Pool({
-  host: process.env.DB_HOST || 'localhost',
-  port: parseInt(process.env.DB_PORT || '5432'),
-  database: process.env.DB_NAME || 'ecommerce_db',
-  user: process.env.DB_USER || 'postgres',
-  password: process.env.DB_PASSWORD || 'password123',
+  host: env.db.host,
+  port: env.db.port,
+  database: env.db.name,
+  user: env.db.user,
+  password: env.db.password,
   max: 20,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000,

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,26 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const requireEnvVar = (key: string): string => {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Environment variable ${key} is required but was not provided.`);
+  }
+  return value;
+};
+
+export const env = {
+  port: parseInt(process.env.PORT || '3001', 10),
+  frontendUrl: process.env.FRONTEND_URL || 'http://localhost:3000',
+  jwtSecret: requireEnvVar('JWT_SECRET'),
+  db: {
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '5432', 10),
+    name: process.env.DB_NAME || 'ecommerce_db',
+    user: process.env.DB_USER || 'postgres',
+    password: process.env.DB_PASSWORD || 'password123',
+  },
+};
+
+export type AppEnv = typeof env;

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { JWTPayload } from '../types';
+import { env } from '../config/env';
 
 declare global {
   namespace Express {
@@ -19,7 +20,7 @@ export const authenticateToken = (req: Request, res: Response, next: NextFunctio
   }
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your_jwt_secret_key_here') as JWTPayload;
+    const decoded = jwt.verify(token, env.jwtSecret) as JWTPayload;
     req.user = decoded;
     next();
   } catch (error) {
@@ -33,7 +34,7 @@ export const optionalAuth = (req: Request, res: Response, next: NextFunction) =>
 
   if (token) {
     try {
-      const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your_jwt_secret_key_here') as JWTPayload;
+      const decoded = jwt.verify(token, env.jwtSecret) as JWTPayload;
       req.user = decoded;
     } catch (error) {
       // Token invalid but continue without user

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,29 +2,27 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
-import dotenv from 'dotenv';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 
 import routes from './routes';
 import pool from './config/database';
-
-dotenv.config();
+import { env } from './config/env';
 
 const app = express();
 const server = createServer(app);
 const io = new Server(server, {
   cors: {
-    origin: process.env.FRONTEND_URL || "http://localhost:3000",
+    origin: env.frontendUrl,
     methods: ["GET", "POST"]
   }
 });
 
-const PORT = process.env.PORT || 3001;
+const PORT = env.port;
 
 app.use(helmet());
 app.use(cors({
-  origin: process.env.FRONTEND_URL || "http://localhost:3000",
+  origin: env.frontendUrl,
   credentials: true
 }));
 app.use(morgan('combined'));

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,6 +1,7 @@
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import pool from '../config/database';
+import { env } from '../config/env';
 import { User, JWTPayload } from '../types';
 
 export class AuthService {
@@ -30,7 +31,7 @@ export class AuthService {
       const user = result.rows[0];
       const token = jwt.sign(
         { user_id: user.user_id, email: user.email } as JWTPayload,
-        process.env.JWT_SECRET || 'your_jwt_secret_key_here',
+        env.jwtSecret,
         { expiresIn: '24h' }
       );
 
@@ -61,7 +62,7 @@ export class AuthService {
 
       const token = jwt.sign(
         { user_id: user.user_id, email: user.email } as JWTPayload,
-        process.env.JWT_SECRET || 'your_jwt_secret_key_here',
+        env.jwtSecret,
         { expiresIn: '24h' }
       );
 


### PR DESCRIPTION
## Summary
- add a centralized environment configuration helper and require JWT_SECRET to be provided
- wire the new helper into the server, database pool, auth service, and auth middleware so no insecure fallback secret is used

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e62be38d80832fa968660d29e3b5e9